### PR TITLE
Added Unofficial .Net 4.0 Support for Oracle

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -197,3 +197,7 @@
     - name: Hangfire_Net40.Redis
       url: https://www.nuget.org/packages/Hangfire_net40.Redis/
       author: phillcampbell
+      
+    - name: Hangfire.Oracle
+      url: https://github.com/CharcoalUchiha/Hangfire.Oracle
+      author: Marcellus Stewart


### PR DESCRIPTION
Still working on this extension for developers using an Oracle database.  Using code from Hangfire.FluentNHibernate as a foundation.