### PR TITLE
Removing Hangfire.MySql - repo no longer exists

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -102,10 +102,6 @@
       url: https://github.com/sergun/Hangfire.Mongo
       author: sergeyzwezdin
       
-    - name: Hangfire.MySql
-      url: https://github.com/chrislove/Hangfire.MySql
-      author: chrislove
-      
     - name: Hangfire.MySqlStorage
       url: https://github.com/arnoldasgudas/Hangfire.MySqlStorage
       author: arnoldasgudas


### PR DESCRIPTION
https://github.com/chrislove/Hangfire.MySql no longer exists - proposing removal from list of extensions