### PR TITLE
Add Hangfire.JobsLogger Extensions & Hangfire.Storage.SQLite Storage

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -174,6 +174,11 @@
     - name: Hangfire.SQLite
       url: https://github.com/wanlitao/HangfireExtension
       author: wanlitao
+      
+    - name: Hangfire.Storage.SQLite
+      description: An Alternative SQLite Storage for Hangfire.
+      url: https://github.com/raisedapp/Hangfire.Storage.SQLite
+      author: felixclase         
 
 - name: IoC Containers
   description: These projects simplify the integration between Hangfire and

--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -89,6 +89,11 @@
       description: A simple dashboard to manage Hangfire's recurring jobs.
       url: https://github.com/bamotav/Hangfire.RecurringJobAdmin
       author: bamotav
+      
+    - name: Hangfire.JobsLogger
+      description: A Hangfire extension to store a log during job execution.
+      url: https://github.com/raisedapp/Hangfire.JobsLogger
+      author: felixclase      
 
 - name: Storages
   description: The following projects enable you to use your favorite storage.


### PR DESCRIPTION
A Hangfire extension to store a log during job execution.

![job_detail](https://user-images.githubusercontent.com/1153361/68401093-87c37800-014f-11ea-9f5e-aaed69b86ea6.png)


![job_logs_history](https://user-images.githubusercontent.com/1153361/68401088-85611e00-014f-11ea-97a5-92ad1df277f7.png)
