### PR TITLE
Update extensions.yml

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -176,10 +176,6 @@
       url: https://github.com/gottscj/Hangfire.Realm
       author: gottscj
       
-    - name: Hangfire.SQLite
-      url: https://github.com/wanlitao/HangfireExtension
-      author: wanlitao
-      
     - name: Hangfire.Storage.SQLite
       description: An Alternative SQLite Storage for Hangfire.
       url: https://github.com/raisedapp/Hangfire.Storage.SQLite


### PR DESCRIPTION
Remove  "Hangfire.SQLite", because 
1. It has compatibility problems with current hangfire version, like backgroundJobs will execute many times
2. it is no maintained a long time (3 years ago)