### PR TITLE
consistency on open-source hyphenation

### DIFF
--- a/licensing/royalty-free.md
+++ b/licensing/royalty-free.md
@@ -54,7 +54,7 @@ We or a certified auditor acting on Our behalf, may, upon its reasonable request
 
 #### 9. THIRD PARTY SOFTWARE
 
-The Software may contain third party open source software which requires notices and/or additional terms and conditions. Such required third party software notices and/or additional terms and conditions are located in the NOTICES file accompanying the Software distribution (also available at https://www.hangfire.io/licensing/third-party.html), and are made a part of and incorporated by reference into this Agreement. By accepting this Agreement, you are also accepting the additional terms and conditions, if any, set forth therein.
+The Software may contain third party open-source software which requires notices and/or additional terms and conditions. Such required third party software notices and/or additional terms and conditions are located in the NOTICES file accompanying the Software distribution (also available at https://www.hangfire.io/licensing/third-party.html), and are made a part of and incorporated by reference into this Agreement. By accepting this Agreement, you are also accepting the additional terms and conditions, if any, set forth therein.
 
 #### 10. PAYMENT AND TAXES
 


### PR DESCRIPTION
don't really have an opinion either way, but consistency is nice.  currently this doesn't match the [standard eula](https://www.hangfire.io/licensing/standard.html)

[this site](https://www.computerhope.com/jargon/o/opensour.htm) says to use the hyphen when it's an adjective modifying a noun which it is in this case.