### PR TITLE
Add IdentityStream.Hangfire.Console to list of extensions

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -15,6 +15,11 @@
       url: https://github.com/bluehands/Hangfire.Community.CarbonAwareExecution
       author: bluehands
 
+    - name: IdentityStream.Hangfire.Console
+      description: Updated fork of Hangfire.Console, a job console extension for Hangfire
+      url: https://github.com/IdentityStream/Hangfire.Console
+      author: IdentityStream
+
     - name: Hangfire.Console
       description: Job console extension for Hangfire
       url: https://github.com/pieceofsummer/Hangfire.Console


### PR DESCRIPTION
As Hangfire.Console seems to be abandoned and has not been updated since 2018, a fork was made by @khellang / @IdentityStream to continue maintaining it. This PR adds that fork to the list of extensions.